### PR TITLE
missing path import in links.py

### DIFF
--- a/links.py
+++ b/links.py
@@ -1,4 +1,4 @@
-from os import symlink, makedirs
+from os import symlink, makedirs, path
 
 from config import MIRROR_BASEDIR, TARGET_BASEDIR
 
@@ -9,6 +9,6 @@ def build_links_sample(filetable):
 
     files = filetable.ftp.map(lambda n : n[len('ftp.sra.ebi.ac.uk/'):]).values
 
-    makedirs(f'{TARGET_BASEDIR}/{s}')
+    makedirs(f'{TARGET_BASEDIR}/{s}', exist_ok=True)
     for f in files:
         symlink(f'{MIRROR_BASEDIR}/{f}',f'{TARGET_BASEDIR}/{s}/'+path.basename(f))


### PR DESCRIPTION
adds also `exist_ok=True` to `makedirs` to avoid new exceptions when re-running after the fix