### PR TITLE
create subdirectories for different experiment types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 config.py
+.env/
+*.jugdata/

--- a/ena.py
+++ b/ena.py
@@ -64,6 +64,10 @@ def get_project_reads_table(accession, as_pandas_DataFrame=False):
                 'submitted_bytes',
                 'read_count',
                 'base_count',
+                'library_layout',
+                'library_strategy',
+                'library_source',
+                'library_selection',
                 ])
     url = '{base_url}?accession={accession}&&result=read_run&fields={fields}'.format(
                 base_url=ENA_FILEREPORT_URL,

--- a/jugfile.py
+++ b/jugfile.py
@@ -3,6 +3,7 @@ import pandas as pd
 from mirror import mirror_all_files, build_link_structure, create_ena_file_map
 from links import build_links_sample
 from config import MIRROR_BASEDIR, USE_ASPERA
+import sys
 
 build_links_sample = TaskGenerator(build_links_sample)
 
@@ -13,7 +14,11 @@ def create_mirror(study_accession, target_directory):
     filetable = ena.expand_fastq_columns(filetable)
     mirror_all_files(filetable, MIRROR_BASEDIR, use_aspera=USE_ASPERA)
     if target_directory != '*':
-        build_link_structure(filetable, MIRROR_BASEDIR, target_directory, study_accession)
+        try:
+            build_link_structure(filetable, MIRROR_BASEDIR, target_directory, study_accession)
+        except IndexError:
+            print("Failed to create link structure for:", study_accession, file=sys.stderr)
+            raise
     return filetable
 
 @TaskGenerator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+jug
+requests


### PR DESCRIPTION
I added checks for library_layout, library_strategy, library_source, library_selection. If there are columns with non-unique values, they get concatenated. E.g. for MeTRS this would create these subdirectories:
```
AMPLICON_PCR
RNA-Seq_cDNA
WGS_RANDOM
```
It doesn't solve all problems, all in this case there are multiple different amplicon strategies. But for the usual metaT/G case, it should work fine. 